### PR TITLE
[design] 홈 화면 디자인 업데이트

### DIFF
--- a/SonMat/Utilities/ColorExtensions.swift
+++ b/SonMat/Utilities/ColorExtensions.swift
@@ -52,17 +52,17 @@ extension Color {
 
     // MARK: Design system colors
 
-    static let accent            = Color(light: "D4603A", dark: "E07550")
-    static let accentDark        = Color(light: "B8482A", dark: "C45A35")
+    static let accent            = Color(light: "C4533A", dark: "E07550")
+    static let accentDark        = Color(light: "A8412B", dark: "C45A35")
     static let accentLight       = Color(light: "FDF0EB", dark: "3D2318")
     static let cardBg            = Color(light: "FFFFFF", dark: "2A2926")
-    static let appBg             = Color(light: "FAFAF8", dark: "1C1B19")
-    static let textPrimary       = Color(light: "1A1A1A", dark: "F2EDE8")
-    static let textSecondary     = Color(light: "6B6B6B", dark: "A8A8A8")
-    static let textTertiary      = Color(light: "6E6E6E", dark: "9E9E9E")
-    static let chipBg            = Color(light: "F0EFEC", dark: "2C2B28")
+    static let appBg             = Color(light: "F7F5F0", dark: "1C1B19")
+    static let textPrimary       = Color(light: "2B2520", dark: "F2EDE8")
+    static let textSecondary     = Color(light: "6B6158", dark: "A8A8A8")
+    static let textTertiary      = Color(light: "9C9488", dark: "9E9E9E")
+    static let chipBg            = Color(light: "EFEBE4", dark: "2C2B28")
     /// Thin divider inside the ingredients box.
-    static let ingredientDivider = Color(light: "EEEDE9", dark: "3A3936")
+    static let ingredientDivider = Color(light: "E8E4DC", dark: "3A3936")
     /// Text color for the selected category chip (inverts with the chip background).
     static let chipSelectedText  = Color(light: "FFFFFF", dark: "1C1B19")
 }

--- a/SonMat/Views/RecipeCardView.swift
+++ b/SonMat/Views/RecipeCardView.swift
@@ -18,7 +18,7 @@ struct RecipeCardView: View {
                         .fill(Color.chipBg)
                 }
             )
-            .frame(width: 80, height: 80)
+            .frame(width: 100, height: 100)
             .clipShape(RoundedRectangle(cornerRadius: 14))
 
             // Content
@@ -46,7 +46,7 @@ struct RecipeCardView: View {
                 Text(recipe.description)
                     .font(.gmarket(13))
                     .foregroundStyle(Color.textSecondary)
-                    .lineLimit(1)
+                    .lineLimit(2)
             }
 
             Spacer(minLength: 0)
@@ -54,13 +54,9 @@ struct RecipeCardView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(recipe.title), \(recipe.category), 총 \(recipe.prepTime + recipe.cookTime)분")
         .accessibilityHint("레시피 상세 보기")
-        .padding(.horizontal, 20)
-        .padding(.vertical, 14)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(Color.chipBg)
-                .frame(height: 0.5)
-        }
+        .padding(12)
+        .background(Color.cardBg)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 }
 

--- a/SonMat/Views/RecipeListView.swift
+++ b/SonMat/Views/RecipeListView.swift
@@ -13,7 +13,7 @@ struct RecipeListView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Header
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text("손맛")
                     .font(.gmarket(26))
                     .fontWeight(.bold)
@@ -25,7 +25,7 @@ struct RecipeListView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 20)
             .padding(.top, 6)
-            .padding(.bottom, 4)
+            .padding(.bottom, 0)
 
             SearchBarView(text: $viewModel.searchText)
                 .padding(.horizontal, 20)
@@ -61,7 +61,7 @@ struct RecipeListView: View {
                 Spacer()
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 0) {
+                    LazyVStack(spacing: 10) {
                         ForEach(viewModel.filteredRecipes) { recipe in
                             NavigationLink(value: recipe) {
                                 RecipeCardView(recipe: recipe)
@@ -69,6 +69,8 @@ struct RecipeListView: View {
                             .buttonStyle(.plain)
                         }
                     }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 10)
                 }
             }
         }
@@ -113,7 +115,7 @@ private struct CategoryChipsView: View {
                             .padding(.horizontal, 16)
                             .background(
                                 Capsule()
-                                    .fill(selectedCategory == category ? Color.textPrimary : Color.chipBg)
+                                    .fill(selectedCategory == category ? Color.accent : Color.chipBg)
                             )
                     }
                     .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Color palette updated to warmer tones matching SonMat.pen design
- Recipe cards: flat rows with separator → white cards with cornerRadius 16
- Thumbnail size: 80x80 → 100x100
- Active category chip: black → accent color
- Header spacing and card gaps aligned to design specs

| AS-IS | TO-BE |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ad507d18-6942-4575-a3d9-11cf265d1146" width=300> | <img src="https://github.com/user-attachments/assets/9952cd5b-8145-4137-a59c-bb1c43e3a20e" width=300> |

## Test plan
- [ ] Verify colors match SonMat.pen design file
- [ ] Verify card layout and spacing on iPhone SE and Pro Max
- [ ] Confirm category chip active state uses accent color
- [ ] Check that description shows 2 lines

Closes #1