### PR TITLE
Fix step image height using 7:4 aspect ratio

### DIFF
--- a/SonMat/Views/RecipeDetailView.swift
+++ b/SonMat/Views/RecipeDetailView.swift
@@ -348,7 +348,7 @@ struct RecipeDetailView: View {
             if let imageURLString = step.imageURL, let url = URL(string: imageURLString) {
                 CachedAsyncImage(url: url, placeholder: { Color.chipBg })
                     .frame(maxWidth: .infinity)
-                    .frame(height: 140)
+                    .aspectRatio(7/4, contentMode: .fit)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
                     .padding(.leading, 40)
                     .accessibilityLabel("\(step.stepNumber)단계 조리 사진")


### PR DESCRIPTION
## Summary
- Replaces hardcoded `.frame(height: 140)` on step images with `.aspectRatio(7/4, contentMode: .fit)`
- Height now scales dynamically with the available width, maintaining a consistent 7:4 ratio across all screen sizes

## Test plan
- [x] Open a recipe with step images and verify images display at 7:4 ratio
- [x] Verify placeholder fills the same space before image loads (no layout jump)
- [x] Check on different device sizes (e.g. iPhone SE vs iPhone 15 Pro Max)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)