### PR TITLE
[feat] 레시피 저장 기능 구현

### DIFF
--- a/SonMat/Persistence/SavedRecipeCache.swift
+++ b/SonMat/Persistence/SavedRecipeCache.swift
@@ -1,0 +1,18 @@
+//
+//  SavedRecipeCache.swift
+//  SonMat
+//
+
+import SwiftData
+import Foundation
+
+@Model
+final class SavedRecipeCache {
+    @Attribute(.unique) var recipeID: UUID
+    var savedAt: Date
+
+    init(recipeID: UUID) {
+        self.recipeID = recipeID
+        self.savedAt = Date()
+    }
+}

--- a/SonMat/SonMatApp.swift
+++ b/SonMat/SonMatApp.swift
@@ -27,6 +27,7 @@ struct SonMatApp: App {
         let schema = Schema([
             RecipeCache.self,
             StepCache.self,
+            SavedRecipeCache.self,
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 

--- a/SonMat/Views/RecipeDetailView.swift
+++ b/SonMat/Views/RecipeDetailView.swift
@@ -14,6 +14,19 @@ struct RecipeDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
     @Environment(\.modelContext) private var modelContext
+    @Query private var savedEntries: [SavedRecipeCache]
+
+    private var isSaved: Bool {
+        savedEntries.contains { $0.recipeID == recipe.id }
+    }
+
+    private func toggleSave() {
+        if let existing = savedEntries.first(where: { $0.recipeID == recipe.id }) {
+            modelContext.delete(existing)
+        } else {
+            modelContext.insert(SavedRecipeCache(recipeID: recipe.id))
+        }
+    }
 
     var body: some View {
         ScrollView {
@@ -35,6 +48,9 @@ struct RecipeDetailView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 backButton
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                bookmarkButton
             }
         }
         .background { NavigationGestureEnabler() }
@@ -135,6 +151,18 @@ struct RecipeDetailView: View {
                 .clipShape(Circle())
         }
         .accessibilityLabel("뒤로")
+    }
+
+    private var bookmarkButton: some View {
+        Button(action: toggleSave) {
+            Image(systemName: isSaved ? "bookmark.fill" : "bookmark")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 36)
+                .background(isSaved ? Color.accent : Color.white.opacity(0.2))
+                .clipShape(Circle())
+        }
+        .accessibilityLabel(isSaved ? "저장됨" : "저장하기")
     }
 
     // MARK: - Metadata

--- a/SonMat/Views/RecipeListView.swift
+++ b/SonMat/Views/RecipeListView.swift
@@ -9,6 +9,13 @@ import SwiftData
 struct RecipeListView: View {
     @Bindable var viewModel: RecipeListViewModel
     @Environment(\.modelContext) private var modelContext
+    @Query(sort: \SavedRecipeCache.savedAt, order: .reverse) private var savedEntries: [SavedRecipeCache]
+
+    private var savedRecipes: [Recipe] {
+        savedEntries.compactMap { entry in
+            viewModel.recipes.first { $0.id == entry.recipeID }
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -26,6 +33,10 @@ struct RecipeListView: View {
             .padding(.horizontal, 20)
             .padding(.top, 6)
             .padding(.bottom, 0)
+
+            if !savedRecipes.isEmpty {
+                savedSection
+            }
 
             SearchBarView(text: $viewModel.searchText)
                 .padding(.horizontal, 20)
@@ -93,6 +104,33 @@ struct RecipeListView: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
+    }
+
+    private var savedSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("저장한 레시피")
+                    .font(.gmarket(15))
+                    .fontWeight(.bold)
+                    .foregroundStyle(Color.textPrimary)
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(savedRecipes) { recipe in
+                        NavigationLink(value: recipe) {
+                            SavedRecipeCardView(recipe: recipe)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+        .padding(.top, 12)
+        .padding(.bottom, 4)
     }
 }
 

--- a/SonMat/Views/SavedRecipeCardView.swift
+++ b/SonMat/Views/SavedRecipeCardView.swift
@@ -1,0 +1,47 @@
+//
+//  SavedRecipeCardView.swift
+//  SonMat
+//
+
+import SwiftUI
+
+struct SavedRecipeCardView: View {
+    let recipe: Recipe
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            CachedAsyncImage(
+                url: recipe.thumbnailURL.flatMap { URL(string: $0) },
+                placeholder: { Color.chipBg }
+            )
+            .frame(width: 110, height: 80)
+            .clipShape(
+                .rect(
+                    topLeadingRadius: 14,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: 14
+                )
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(recipe.title)
+                    .font(.gmarket(13))
+                    .fontWeight(.bold)
+                    .foregroundStyle(Color.textPrimary)
+                    .lineLimit(1)
+
+                Text("\(recipe.category) · \(recipe.prepTime + recipe.cookTime)분")
+                    .font(.gmarket(11))
+                    .foregroundStyle(Color.textTertiary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 8)
+            .padding(.top, 6)
+            .padding(.bottom, 8)
+        }
+        .frame(width: 110)
+        .background(Color.cardBg)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}


### PR DESCRIPTION
## Summary
- 북마크 버튼을 `RecipeDetailView` 우상단에 추가 — 저장 시 accent 색상(solid)으로 변경, 미저장 시 반투명 흰색
- `RecipeListView` 상단에 "저장한 레시피" 가로 스크롤 섹션 추가 (저장 레시피 없을 시 숨김)
- `SavedRecipeCache` SwiftData 모델 신규 추가 — 레시피 UUID만 로컬 저장, Supabase와 무관

## Test plan
- [x] 레시피 상세 화면 진입 → 우상단 북마크 버튼 확인
- [x] 북마크 탭 → 버튼이 accent 색상(filled)으로 변경되는지 확인
- [x] 홈 화면으로 복귀 → "저장한 레시피" 섹션에 카드 노출 확인
- [x] 다시 북마크 탭 → 버튼 원래대로, 섹션 사라지는지 확인
- [x] 앱 재시작 → 저장 상태 유지 확인 (SwiftData 영속성)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)