### PR TITLE
[feat] 디스크 기반 이미지 캐시 레이어 추가

### DIFF
--- a/SonMat/Utilities/ImageCache.swift
+++ b/SonMat/Utilities/ImageCache.swift
@@ -4,11 +4,22 @@
 //
 
 import SwiftUI
+import CryptoKit
 
 final class ImageCache {
     static let shared = ImageCache()
     private let cache = NSCache<NSURL, UIImage>()
-    private init() {}
+    private let cacheDirectory: URL
+
+    private init() {
+        cacheDirectory = FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("ImageCache", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Memory tier
 
     func image(for url: URL) -> UIImage? {
         cache.object(forKey: url as NSURL)
@@ -16,6 +27,48 @@ final class ImageCache {
 
     func insert(_ image: UIImage, for url: URL) {
         cache.setObject(image, forKey: url as NSURL)
+    }
+
+    // MARK: - Disk tier
+
+    func imageFromDisk(for url: URL) -> UIImage? {
+        let fileURL = cacheDirectory.appendingPathComponent(cacheKey(for: url))
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return UIImage(data: data)
+    }
+
+    func saveToDisk(_ image: UIImage, for url: URL) {
+        Task.detached(priority: .background) { [weak self] in
+            guard let self,
+                  let data = image.jpegData(compressionQuality: 0.85) else { return }
+            let fileURL = self.cacheDirectory.appendingPathComponent(self.cacheKey(for: url))
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    // MARK: - Cache management
+
+    func clearDiskCache() {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: cacheDirectory, includingPropertiesForKeys: nil) else { return }
+        files.forEach { try? FileManager.default.removeItem(at: $0) }
+    }
+
+    func diskCacheSize() -> Int64 {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: cacheDirectory, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
+        return files.reduce(0) { total, fileURL in
+            let size = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+            return total + Int64(size)
+        }
+    }
+
+    // MARK: - Private
+
+    private func cacheKey(for url: URL) -> String {
+        SHA256.hash(data: Data(url.absoluteString.utf8))
+            .compactMap { String(format: "%02x", $0) }
+            .joined() + ".jpg"
     }
 }
 
@@ -40,13 +93,23 @@ struct CachedAsyncImage<Placeholder: View>: View {
 
     private func load() async {
         guard let url else { return }
+
+        // 1단계: 메모리
         if let cached = ImageCache.shared.image(for: url) {
             uiImage = cached
             return
         }
+        // 2단계: 디스크
+        if let diskImage = ImageCache.shared.imageFromDisk(for: url) {
+            ImageCache.shared.insert(diskImage, for: url)
+            uiImage = diskImage
+            return
+        }
+        // 3단계: 네트워크
         guard let (data, _) = try? await URLSession.shared.data(from: url),
               let loaded = UIImage(data: data) else { return }
         ImageCache.shared.insert(loaded, for: url)
+        ImageCache.shared.saveToDisk(loaded, for: url)
         uiImage = loaded
     }
 }


### PR DESCRIPTION
## Summary

- `NSCache` 메모리 캐시만 존재하던 `ImageCache`에 `FileManager` 기반 디스크 캐시 레이어를 추가
- `CachedAsyncImage.load()` 조회 순서를 메모리 → 디스크 → 네트워크 3단계로 변경
- 앱 재시작 후 이미지 재다운로드 없이 즉시 표시, Supabase Storage 요청 횟수 감소

## Changes

- `Library/Caches/ImageCache/` 디렉토리에 JPEG(quality 0.85)로 저장 (OS가 디스크 압박 시 자동 정리)
- URL을 SHA256 해시해 충돌 없는 파일명 생성
- 디스크 쓰기는 `Task.detached(priority: .background)` fire-and-forget으로 처리 (UI 블로킹 없음)
- `clearDiskCache()` / `diskCacheSize()` 메서드 추가 — Issue #11 InfoView 캐시 삭제 UI에서 사용 예정
- `RecipeCardView`, `SavedRecipeCardView`, `RecipeDetailView` 등 기존 뷰 수정 없음

## Test plan

- [ ] 앱 첫 실행 → 레시피 목록 스크롤하여 이미지 다운로드 확인
- [ ] 앱 강제 종료 후 재실행 → 이미지가 즉시 표시되는지 확인
- [ ] Xcode Network Profiler에서 Supabase Storage 요청이 없는지 확인
- [ ] Xcode Devices에서 `Library/Caches/ImageCache/` 디렉토리에 `.jpg` 파일 생성 확인

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)